### PR TITLE
Added more in HTTP status codes and text in the status code map

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -28,8 +28,10 @@ class ResponseMessage extends Writable {
         const statusTexts = {
             200: "OK",
             201: "Created",
+            202: "Accepted",
             204: "No Content",
-            301: "Moved Permanetly",
+            206: "Partial Content",
+            301: "Moved Permanently",
             302: "Found",
             304: "Not Modified",
             400: "Bad Request",
@@ -38,10 +40,16 @@ class ResponseMessage extends Writable {
             404: "Not Found",
             405: "Method Not Allowed",
             409: "Conflict",
+            410: "Permanently Deleted",
+            413: "Payload Too Large",
+            415: "Unsupported Content Type",
             422: "Unprocessable Entity",
+            429: "Too Many Requests",
             500: "Internal Server Error",
+            501: "Feature Not Implemented",
             502: "Bad Gateway",
             503: "Service Unavailable",
+            504: "Gateway Timeout",
         };
 
         return statusTexts.hasOwnProperty(statusCode)


### PR DESCRIPTION
I added 202, 206, 410, 413, 415, 501, 504 status codes to the status code map. 

More research will be needed for a concise status text for

301: Permanent redirect that changes method to get

302: temporary redirect that changes method to "GET" ::: this was written as found in the codebase which is wrong.

307: temporary redirect that doesn't change method

308: Permanent redirect that doesn't change method